### PR TITLE
Replace Badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nacelle Klaviyo Nuxt Module
 
 [![npm version](https://img.shields.io/npm/v/@nacelle/nacelle-klaviyo-nuxt-module.svg)](https://www.npmjs.com/package/@nacelle/nacelle-klaviyo-nuxt-module)
-[![install size](https://packagephobia.now.sh/badge?p=@nacelle/nacelle-klaviyo-nuxt-module)](https://packagephobia.now.sh/result?p=@nacelle/nacelle-klaviyo-nuxt-module)
+[![install size](https://badgen.net/bundlephobia/minzip/@nacelle/nacelle-klaviyo-nuxt-module)](https://badgen.net/bundlephobia/minzip/@nacelle/nacelle-klaviyo-nuxt-module)
 
 Adds Vue.js components for displaying [Klaviyo](https://www.klaviyo.com/) forms in your [Nacelle](https://getnacelle.com/) Nuxt project.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/nacelle-klaviyo-nuxt-module",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/nacelle-klaviyo-nuxt-module",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Integrates Klaviyo into your Nacelle Nuxt project",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
### What Does This Do?
- Switches README badge from Package Phobia to Bundle Phobia

### Why
My [last PR](https://github.com/getnacelle/nacelle-klaviyo-nuxt-module/pull/1) added a badge for [Package Phobia](packagephobia.now.sh/), which shows you the install size / effect of installing the package on your local disk.

What is more interesting for this type of package is its impact on an application's bundle size. This is given by [Bundle Phobia](https://bundlephobia.com/).