### PR TITLE
Fix Product ID Sent to Klaviyo

### DIFF
--- a/lib/nacelle-klaviyo-plugin.js
+++ b/lib/nacelle-klaviyo-plugin.js
@@ -9,7 +9,7 @@ const viewedProduct = (product) => {
     const _learnq = window._learnq || []
     const item = {
       Name: product.title,
-      ProductID: product.id,
+      ProductID: product.pimSyncSourceProductId,
       Categories: product.tags,
       ImageURL: product.featuredMedia.src,
       URL: `${window.location.origin}/products/${product.handle}`,

--- a/lib/nacelle-klaviyo-plugin.js
+++ b/lib/nacelle-klaviyo-plugin.js
@@ -9,7 +9,10 @@ const viewedProduct = (product) => {
     const _learnq = window._learnq || []
     const item = {
       Name: product.title,
-      ProductID: product.pimSyncSourceProductId,
+      ProductID: Buffer.from(product.pimSyncSourceProductId, "base64")
+        .toString("binary")
+        .split("/")
+        .pop(),
       Categories: product.tags,
       ImageURL: product.featuredMedia.src,
       URL: `${window.location.origin}/products/${product.handle}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/nacelle-klaviyo-nuxt-module",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Integrates Klaviyo into your Nacelle Nuxt project",
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/nacelle-klaviyo-nuxt-module",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Integrates Klaviyo into your Nacelle Nuxt project",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- Fixes [[NC-1485](https://nacelle.atlassian.net/browse/NC-1485)] <!-- link to Jira or Github issue if one exists -->
  - > Incorrect product ID sent to Klaviyo by @nacelle/nacelle-klaviyo-nuxt-module

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR fixes an issue in which `@nacelle/nacelle-klaviyo-nuxt-module` was sending the `id` (e.g. `starship-furniture.myshopify.com::satellite-console::en-us`) instead of the decoded product ID from the `pimSyncSourceProductId`(e.g. `1473833664548`).
